### PR TITLE
reonce: use LiteralPrefix instead of Longest in init benchmarks

### DIFF
--- a/reonce.go
+++ b/reonce.go
@@ -9,12 +9,14 @@ import (
 	"sync"
 )
 
+// Regexp is a lazily initialized regexp.Regexp. A Regexp is safe for concurrent
+// use by multiple goroutines, except for configuration methods, such as Longest.
 type Regexp struct {
 	rx    *regexp.Regexp
 	once  sync.Once
-	posix bool // pack this after once to save space
-	expr  string
-	err   error
+	posix bool   // pack this after once to save space
+	expr  string // as passed to Compile
+	err   error  // Compile error, if any
 }
 
 // New returns a new lazily initialized Regexp. The underlying *regexp.Regexp

--- a/reonce_test.go
+++ b/reonce_test.go
@@ -266,14 +266,14 @@ func TestLazyCompileParallel(t *testing.T) {
 func BenchmarkInitOverhead(b *testing.B) {
 	re := New("a")
 	for i := 0; i < b.N; i++ {
-		re.Longest() // cheapest method
+		re.LiteralPrefix() // cheapest method
 	}
 }
 
 func BenchmarkInitOverhead_Baseline(b *testing.B) {
 	re := regexp.MustCompile("a")
 	for i := 0; i < b.N; i++ {
-		re.Longest() // cheapest method
+		re.LiteralPrefix()
 	}
 }
 
@@ -281,19 +281,16 @@ func BenchmarkInitOverhead_Parallel(b *testing.B) {
 	re := New("a")
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			re.Longest()
+			re.LiteralPrefix()
 		}
 	})
-	for i := 0; i < b.N; i++ {
-		re.Longest() // cheapest method
-	}
 }
 
 func BenchmarkInitOverhead_Parallel_Baseline(b *testing.B) {
 	re := regexp.MustCompile("a")
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			re.Longest()
+			re.LiteralPrefix()
 		}
 	})
 }


### PR DESCRIPTION
Change the init benchmarks to use LiteralPrefix() instead of Longest()
since it is thread-safe and fast.

This commit also documents the Regexp type.